### PR TITLE
Add toolchain caching

### DIFF
--- a/.github/workflows/cross-compiler.yml
+++ b/.github/workflows/cross-compiler.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   build-cross-compiler:
     runs-on: ubuntu-latest
+    env:
+      GCC_VERSION: "14.1.0"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -16,10 +18,18 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y build-essential bison flex libgmp3-dev libmpc-dev libmpfr-dev texinfo wget
 
+      - name: Cache cross compiler
+        id: cross-cache
+        uses: actions/cache@v3
+        with:
+          path: ${{ github.workspace }}/opt/cross
+          key: ${{ runner.os }}-cross-${{ env.GCC_VERSION }}
+
       - name: Build binutils and gcc
+        if: steps.cross-cache.outputs.cache-hit != 'true'
         env:
           BINUTILS_VERSION: "2.44"
-          GCC_VERSION: "14.1.0"
+          GCC_VERSION: "${{ env.GCC_VERSION }}"
           PREFIX: "${{ github.workspace }}/opt/cross"
           TARGET: "i686-elf"
           PATH: "${{ github.workspace }}/opt/cross/bin:${PATH}"


### PR DESCRIPTION
## Summary
- cache cross compiler output using actions/cache
- skip GCC/binutils build when cache hit

## Testing
- `git status --short`