### PR TITLE
Add CROSS_PREFIX variable support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
-CC=i686-elf-gcc
+CROSS_PREFIX ?= i686-elf-
+CC := $(CROSS_PREFIX)gcc
+AS := $(CROSS_PREFIX)as
 CFLAGS=-I.
 
 BIN=naxos.bin
@@ -17,7 +19,7 @@ $(BIN): $(OBJ)
 %.o: %.c
 	$(CC) -o $@ -c $^ -std=gnu99 -ffreestanding -O2 -Wall -Wextra
 $(GAS_OBJ): $(GAS)
-	i686-elf-as $^ -o $@
+	$(AS) $^ -o $@
 $(NASM_OBJ): $(NASM)
 	nasm -f elf32 $^ -o $@
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,13 @@
 # naxos
 
 Just wanted to play with a shell of an x86 based operating system.
+
+## Building
+
+The `Makefile` assumes a cross compiler using the `i686-elf-` prefix. If your
+toolchain uses a different prefix, set the `CROSS_PREFIX` variable when
+invoking `make`:
+
+```sh
+make CROSS_PREFIX=arm-none-eabi-
+```


### PR DESCRIPTION
## Summary
- add `CROSS_PREFIX` variable to `Makefile`
- use `$(AS)` for assembly
- document how to use `CROSS_PREFIX` in the README

## Testing
- `make clean`
- `make` *(fails: `i686-elf-as` missing)*