### PR TITLE
Add compiler cache to workflow

### DIFF
--- a/.github/workflows/cross-compiler.yml
+++ b/.github/workflows/cross-compiler.yml
@@ -23,6 +23,13 @@ jobs:
         run: |
           which mkdir
           mkdir --version
+
+      - name: Cache cross compiler
+        id: cross-cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ github.workspace }}/opt/cross
+          key: ${{ runner.os }}-cross-${{ env.GCC_VERSION }}-binutils-2.44
       
       - name: Build binutils and gcc
         if: steps.cross-cache.outputs.cache-hit != 'true'


### PR DESCRIPTION
## Summary
- cache built cross compiler to reuse across workflows

## Testing
- `make clean`