### PR TITLE
Update build to consume cross compiler

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,10 +5,15 @@ on:
   pull_request:
 
 jobs:
+  cross-compiler:
+    uses: ./.github/workflows/cross-compiler.yml
+
   build:
+    needs: cross-compiler
     runs-on: ubuntu-latest
     env:
       GCC_VERSION: "14.1.0"
+      COMPILER_PATH: ${{ needs.cross-compiler.outputs.compiler-path }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
@@ -17,12 +22,12 @@ jobs:
         id: cross-cache
         uses: actions/cache@v3
         with:
-          path: opt/cross
+          path: ${{ env.COMPILER_PATH }}
           key: ${{ runner.os }}-cross-${{ env.GCC_VERSION }}
 
       - name: Build kernel
         env:
-          PATH: "${{ github.workspace }}/opt/cross/bin:${PATH}"
+          PATH: "${{ env.COMPILER_PATH }}/bin:${PATH}"
         run: make
 
       - name: Upload kernel

--- a/.github/workflows/cross-compiler.yml
+++ b/.github/workflows/cross-compiler.yml
@@ -3,10 +3,17 @@ name: Build Cross Compiler
 on:
   push:
   pull_request:
+  workflow_call:
+    outputs:
+      compiler-path:
+        description: "Location of the built cross compiler"
+        value: ${{ jobs.build-cross-compiler.outputs.compiler-path }}
 
 jobs:
   build-cross-compiler:
     runs-on: ubuntu-latest
+    outputs:
+      compiler-path: ${{ steps.set-path.outputs.compiler-path }}
     env:
       GCC_VERSION: "14.1.0"
     steps:
@@ -31,9 +38,9 @@ jobs:
           path: ${{ github.workspace }}/opt/cross
           key: ${{ runner.os }}-cross-${{ env.GCC_VERSION }}-binutils-2.44
       
-      - name: Build binutils and gcc
-        if: steps.cross-cache.outputs.cache-hit != 'true'
-        env:
+        - name: Build binutils and gcc
+          if: steps.cross-cache.outputs.cache-hit != 'true'
+          env:
           BINUTILS_VERSION: "2.44"
           GCC_VERSION: "${{ env.GCC_VERSION }}"
           PREFIX: "${{ github.workspace }}/opt/cross"
@@ -64,3 +71,7 @@ jobs:
           make -j$(nproc) all-target-libgcc
           make install-gcc
           make install-target-libgcc
+
+        - name: Set compiler output path
+          id: set-path
+          run: echo "compiler-path=${{ github.workspace }}/opt/cross" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
## Summary
- build the cross compiler as a reusable workflow
- depend on the cross compiler when building the kernel
- pass the cross compiler path via workflow outputs

## Testing
- `make clean`
- `make` *(fails: `i686-elf-as: No such file or directory`)*