### PR TITLE
Add run target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,12 @@ $(GAS_OBJ): $(GAS)
 $(NASM_OBJ): $(NASM)
 	nasm -f elf32 $^ -o $@
 
-.PHONY : clean
+.PHONY : clean run
 clean :
 	-rm -f $(BIN) $(OBJ)
+run: $(BIN)
+	if [ -x ./start-qemu.sh ]; then \
+		./start-qemu.sh; \
+	else \
+		qemu-system-i386 -cpu pentium3 --serial file:serial.log -kernel $(BIN); \
+	fi

--- a/README.md
+++ b/README.md
@@ -11,3 +11,14 @@ invoking `make`:
 ```sh
 make CROSS_PREFIX=arm-none-eabi-
 ```
+
+## Running
+
+After building the kernel you can boot it in QEMU with:
+
+```sh
+make run
+```
+
+The `run` target will execute `start-qemu.sh` if it exists, or fall back to
+calling `qemu-system-i386` directly.


### PR DESCRIPTION
## Summary
- add a `run` target to the `Makefile` for launching qemu
- document running the kernel with `make run`

## Testing
- `make` *(fails: i686-elf-as: No such file or directory)*
- `make run` *(fails: i686-elf-as: No such file or directory)*
