### PR TITLE
Add build script for cross compiler

### DIFF
--- a/.github/workflows/cross-compiler.yml
+++ b/.github/workflows/cross-compiler.yml
@@ -35,43 +35,18 @@ jobs:
         id: cross-cache
         uses: actions/cache@v4
         with:
-          path: ${{ github.workspace }}/opt/cross
+          path: ${{ github.workspace }}/vendor/cross
           key: ${{ runner.os }}-cross-${{ env.GCC_VERSION }}-binutils-2.44
 
-      - name: Build binutils and gcc
+      - name: Build cross compiler
         if: steps.cross-cache.outputs.cache-hit != 'true'
         env:
           BINUTILS_VERSION: "2.44"
           GCC_VERSION: "${{ env.GCC_VERSION }}"
-          PREFIX: "${{ github.workspace }}/opt/cross"
+          PREFIX: "${{ github.workspace }}/vendor/cross"
           TARGET: "i686-elf"
-          PATH: "/usr/bin:/bin:${{ github.workspace }}/opt/cross/bin:${PATH}"
-        run: |
-          set -e
-          mkdir -p $HOME/src
-          cd $HOME/src
-
-          wget https://ftp.gnu.org/gnu/binutils/binutils-$BINUTILS_VERSION.tar.gz
-          tar -xvzf binutils-$BINUTILS_VERSION.tar.gz
-          mkdir build-binutils
-          cd build-binutils
-          ../binutils-$BINUTILS_VERSION/configure --target=$TARGET --prefix="$PREFIX" --with-sysroot --disable-nls --disable-werror
-          make -j$(nproc)
-          make install
-      
-          cd $HOME/src
-          wget https://ftp.gnu.org/gnu/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.gz
-          tar -xvzf gcc-$GCC_VERSION.tar.gz
-          cd gcc-$GCC_VERSION
-          ./contrib/download_prerequisites
-          mkdir ../build-gcc
-          cd ../build-gcc
-          ../gcc-$GCC_VERSION/configure --target=$TARGET --prefix="$PREFIX" --disable-nls --enable-languages=c --without-headers
-          make -j$(nproc) all-gcc
-          make -j$(nproc) all-target-libgcc
-          make install-gcc
-          make install-target-libgcc
+        run: vendor/build_cross_compiler.sh
 
       - name: Set compiler output path
         id: set-path
-        run: echo "compiler-path=${{ github.workspace }}/opt/cross" >> "$GITHUB_OUTPUT"
+        run: echo "compiler-path=${{ github.workspace }}/vendor/cross" >> "$GITHUB_OUTPUT"

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 *.bin
 *.swp
 *.log
+vendor/cross/

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,8 @@
+ifeq ($(wildcard vendor/cross/bin/i686-elf-gcc),)
 CROSS_PREFIX ?= i686-elf-
+else
+CROSS_PREFIX ?= vendor/cross/bin/i686-elf-
+endif
 CC := $(CROSS_PREFIX)gcc
 AS := $(CROSS_PREFIX)as
 CFLAGS=-I.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,20 @@ invoking `make`:
 make CROSS_PREFIX=arm-none-eabi-
 ```
 
+If you don't already have an `i686-elf` toolchain installed you can build one
+with the provided script:
+
+```sh
+./vendor/build_cross_compiler.sh
+```
+
+When the script completes, add the compiler to your `PATH` so `make` can find
+it automatically:
+
+```sh
+export PATH="$PWD/vendor/cross/bin:$PATH"
+```
+
 ## Running
 
 After building the kernel you can boot it in QEMU with:

--- a/vendor/build_cross_compiler.sh
+++ b/vendor/build_cross_compiler.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+BINUTILS_VERSION="${BINUTILS_VERSION:-2.44}"
+GCC_VERSION="${GCC_VERSION:-14.1.0}"
+TARGET="${TARGET:-i686-elf}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PREFIX="${PREFIX:-$SCRIPT_DIR/cross}"
+PATH="$PREFIX/bin:$PATH"
+
+if [ -x "$PREFIX/bin/${TARGET}-gcc" ]; then
+  echo "Cross compiler already built at $PREFIX"
+  exit 0
+fi
+
+mkdir -p "$SCRIPT_DIR/src"
+cd "$SCRIPT_DIR/src"
+
+wget https://ftp.gnu.org/gnu/binutils/binutils-$BINUTILS_VERSION.tar.gz
+if [ -d binutils-$BINUTILS_VERSION ]; then
+  rm -rf binutils-$BINUTILS_VERSION
+fi
+tar -xvzf binutils-$BINUTILS_VERSION.tar.gz
+mkdir build-binutils
+cd build-binutils
+../binutils-$BINUTILS_VERSION/configure --target=$TARGET --prefix="$PREFIX" --with-sysroot --disable-nls --disable-werror
+make -j$(nproc)
+make install
+
+cd "$SCRIPT_DIR/src"
+wget https://ftp.gnu.org/gnu/gcc/gcc-$GCC_VERSION/gcc-$GCC_VERSION.tar.gz
+if [ -d gcc-$GCC_VERSION ]; then
+  rm -rf gcc-$GCC_VERSION
+fi
+tar -xvzf gcc-$GCC_VERSION.tar.gz
+cd gcc-$GCC_VERSION
+./contrib/download_prerequisites
+mkdir ../build-gcc
+cd ../build-gcc
+../gcc-$GCC_VERSION/configure --target=$TARGET --prefix="$PREFIX" --disable-nls --enable-languages=c --without-headers
+make -j$(nproc) all-gcc
+make -j$(nproc) all-target-libgcc
+make install-gcc
+make install-target-libgcc
+


### PR DESCRIPTION
## Summary
- provide a vendored cross compiler build script
- build the cross compiler under `vendor/cross` in CI
- ignore `vendor/cross` path in git
- default `CROSS_PREFIX` to the vendored compiler if present
- document how to build and use the vendored compiler

## Testing
- `make clean`