### PR TITLE
Fix PATH for make

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Build kernel
         env:
-          PATH: "${{ env.COMPILER_PATH }}/bin:${PATH}"
+          PATH: ${{ env.COMPILER_PATH }}/bin:${{ env.PATH }}
         run: make
 
       - name: Upload kernel


### PR DESCRIPTION
## Summary
- fix PATH reference in build.yml to use env.PATH

## Testing
- `make` *(fails: i686-elf-as: No such file or directory)*