### PR TITLE
Update build workflow with release step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,3 +38,10 @@ jobs:
         with:
           name: naxos-bin
           path: naxos.bin
+
+      - name: Create release
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: naxos.bin
+          generate_release_notes: true


### PR DESCRIPTION
## Summary
- add GitHub release step to build workflow

## Testing
- `make` *(fails: i686-elf-as: No such file or directory)*