### PR TITLE
Add LFS cross compiler integration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+vendor/cross/** filter=lfs diff=lfs merge=lfs -text

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          lfs: true
 
       - name: Install build tools
         run: |

--- a/.github/workflows/cross-compiler.yml
+++ b/.github/workflows/cross-compiler.yml
@@ -13,13 +13,16 @@ jobs:
   build-cross-compiler:
     runs-on: ubuntu-latest
     outputs:
-      compiler-path: ${{ steps.set-path.outputs.compiler-path }}
+      compiler-path: ${{ steps.resolve-path.outputs.compiler-path }}
     env:
       GCC_VERSION: "14.1.0"
       BINUTILS_VERSION: "2.44"
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          lfs: true
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install build dependencies
         run: |
@@ -32,7 +35,17 @@ jobs:
           which mkdir
           mkdir --version
 
+      - name: Check cross compiler in repo
+        id: cross-lfs
+        run: |
+          if [ -x "$GITHUB_WORKSPACE/vendor/cross/bin/i686-elf-gcc" ]; then
+            echo "found=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "found=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Cache cross compiler
+        if: steps.cross-lfs.outputs.found != 'true'
         id: cross-cache
         uses: actions/cache@v4
         with:
@@ -40,7 +53,7 @@ jobs:
           key: ${{ runner.os }}-cross-${{ env.GCC_VERSION }}-binutils-${{ env.BINUTILS_VERSION }}
 
       - name: Build cross compiler
-        if: steps.cross-cache.outputs.cache-hit != 'true'
+        if: steps.cross-lfs.outputs.found != 'true' && steps.cross-cache.outputs.cache-hit != 'true'
         env:
           BINUTILS_VERSION: "${{ env.BINUTILS_VERSION }}"
           GCC_VERSION: "${{ env.GCC_VERSION }}"
@@ -50,6 +63,15 @@ jobs:
           chmod +x vendor/build_cross_compiler.sh
           vendor/build_cross_compiler.sh
 
-      - name: Set compiler output path
-        id: set-path
+      - name: Add cross compiler to repo
+        if: steps.cross-lfs.outputs.found != 'true' && steps.cross-cache.outputs.cache-hit != 'true'
+        run: |
+          git config user.name "github-actions"
+          git config user.email "github-actions@github.com"
+          git add vendor/cross
+          git commit -m "Add prebuilt cross compiler" || echo "nothing to commit"
+          git push
+
+      - name: Resolve compiler path
+        id: resolve-path
         run: echo "compiler-path=${{ github.workspace }}/vendor/cross" >> "$GITHUB_OUTPUT"

--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ Just wanted to play with a shell of an x86 based operating system.
 
 ## Building
 
+This repository stores the prebuilt cross compiler using [Git LFS](https://git-lfs.com/).
+If you haven't enabled LFS, install it and run `git lfs pull` after cloning to
+retrieve the compiler binaries.
+
 The `Makefile` assumes a cross compiler using the `i686-elf-` prefix. If your
 toolchain uses a different prefix, set the `CROSS_PREFIX` variable when
 invoking `make`:
@@ -13,7 +17,8 @@ make CROSS_PREFIX=arm-none-eabi-
 ```
 
 If you don't already have an `i686-elf` toolchain installed you can build one
-with the provided script:
+with the provided script. The repository may also include a prebuilt toolchain
+under `vendor/cross` if Git LFS objects were fetched during checkout:
 
 ```sh
 ./vendor/build_cross_compiler.sh


### PR DESCRIPTION
## Summary
- track `vendor/cross` binaries with Git LFS
- note Git LFS usage in README
- update workflows to pull LFS data
- have workflow check repo for prebuilt cross compiler before caching/building

## Testing
- `apt-get update` *(fails: Could not resolve host)*
- `make --version`
