### PR TITLE
Add cross compiler release step

### DIFF
--- a/.github/workflows/cross-compiler.yml
+++ b/.github/workflows/cross-compiler.yml
@@ -6,6 +6,9 @@ on:
       compiler-path:
         description: "Location of the built cross compiler"
         value: ${{ jobs.build-cross-compiler.outputs.compiler-path }}
+  push:
+    tags:
+      - '*'
 
 jobs:
   build-cross-compiler:
@@ -69,6 +72,18 @@ jobs:
           git add vendor/cross
           git commit -m "Add prebuilt cross compiler" || echo "nothing to commit"
           git push
+
+      - name: Package cross compiler
+        if: startsWith(github.ref, 'refs/tags/')
+        run: |
+          tar -C vendor -czf cross.tar.gz cross
+
+      - name: Release cross compiler
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v1
+        with:
+          files: cross.tar.gz
+          generate_release_notes: true
 
       - name: Resolve compiler path
         id: resolve-path

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ The kernel and cross‑compiler are built automatically on GitHub Actions. The
 workflow in `.github/workflows/build.yml` triggers the `cross-compiler` job
 defined in `.github/workflows/cross-compiler.yml`.
 
+When the workflow runs for a tagged commit, the generated cross compiler is
+packaged and published as a GitHub release.
+
 The cross‑compiler workflow installs the build dependencies
 `build-essential`, `bison`, `flex`, `libgmp3-dev`, `libmpc-dev`, `libmpfr-dev`,
 `texinfo`, `wget`, and `coreutils`. It then builds an `i686-elf` toolchain using


### PR DESCRIPTION
## Summary
- save the cross compiler as a GitHub release when a tag is pushed
- document the automatic release in the README

## Testing
- `make` *(fails: `i686-elf-as: No such file or directory`)*
- `shellcheck vendor/build_cross_compiler.sh` *(fails: command not found)*