### PR TITLE
Add kernel test workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -43,6 +43,16 @@ jobs:
           PATH: ${{ env.COMPILER_PATH }}/bin:/usr/local/bin:/usr/bin:/bin
         run: make
 
+      - name: Install QEMU
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y qemu-system-i386
+
+      - name: Run kernel tests
+        env:
+          PATH: ${{ env.COMPILER_PATH }}/bin:/usr/local/bin:/usr/bin:/bin
+        run: ./test_kernel.sh
+
       - name: Upload kernel
         uses: actions/upload-artifact@v4
         with:

--- a/test_kernel.sh
+++ b/test_kernel.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euxo pipefail
+
+make clean
+make
+
+rm -f serial.log
+# Boot kernel in QEMU and send ESC to exit the keyboard loop
+# Use timeout to ensure the test finishes if the kernel hangs
+if command -v qemu-system-i386 >/dev/null; then
+  timeout 10s qemu-system-i386 -display none -serial file:serial.log \
+    -no-reboot -no-shutdown -kernel naxos.bin -sendkey esc || true
+  grep -q "Hello, kernel World!" serial.log
+else
+  echo "qemu-system-i386 not installed" >&2
+  exit 1
+fi


### PR DESCRIPTION
## Summary
- add a basic test script that builds the kernel and boots it in QEMU
- run the new test in the build workflow

## Testing
- `./test_kernel.sh` *(fails: i686-elf-as: No such file or directory)*