### PR TITLE
Add setup script

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ export PATH="$PWD/vendor/cross/bin:$PATH"
 
 To build the toolchain yourself, execute `./vendor/build_cross_compiler.sh`.
 
+Install host dependencies with:
+
+```sh
+./setup.sh
+```
+
 ## Build and Run
 
 Compile with `make` and boot in QEMU using:

--- a/setup.sh
+++ b/setup.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Install required packages
+sudo apt-get update
+sudo apt-get install -y g++ make cppcheck
+
+# Verify installations
+for cmd in g++ make cppcheck; do
+    if ! command -v "$cmd" >/dev/null 2>&1; then
+        echo "$cmd was not installed successfully" >&2
+        exit 1
+    fi
+    "$cmd" --version | head -n 1
+done
+
+echo "All packages installed successfully."


### PR DESCRIPTION
## Summary
- add a `setup.sh` script to install g++, make and cppcheck
- document running `./setup.sh` in README

## Testing
- `make` *(fails: i686-elf-as: No such file or directory)*