### PR TITLE
Add CROSS_PREFIX support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,4 @@
-ifeq ($(wildcard vendor/cross/bin/i686-elf-gcc),)
 CROSS_PREFIX ?= i686-elf-
-else
-CROSS_PREFIX ?= vendor/cross/bin/i686-elf-
-endif
 CC := $(CROSS_PREFIX)gcc
 AS := $(CROSS_PREFIX)as
 CFLAGS=-I.
@@ -25,7 +21,7 @@ $(BIN): $(OBJ)
 $(GAS_OBJ): $(GAS)
 	$(AS) $^ -o $@
 $(NASM_OBJ): $(NASM)
-	nasm -f elf32 $^ -o $@
+	$(AS) $^ -o $@
 
 .PHONY : clean run
 clean :

--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ Compile with `make` and boot in QEMU using:
 make run
 ```
 
-Override the compiler prefix with `make CROSS_PREFIX=<prefix>` if needed.
+The Makefile looks for a cross compiler using the `CROSS_PREFIX` variable.
+It defaults to `i686-elf-`. Override it with `make CROSS_PREFIX=<prefix>` if
+your tools use a different prefix or reside in a custom location.
 
 ## Expected Behavior
 


### PR DESCRIPTION
## Summary
- simplify cross compiler detection
- allow overriding CROSS_PREFIX
- update assembly rule to use $(AS)
- document CROSS_PREFIX variable

## Testing
- `./setup.sh` *(fails: repository not signed)*
- `make` *(fails: i686-elf-as missing)*
- `cppcheck *.c` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684d6b2e1b9c8332be3c3fb332631962